### PR TITLE
Unshift released connections to release idle connections sooner

### DIFF
--- a/src/ConnectionPool.php
+++ b/src/ConnectionPool.php
@@ -316,7 +316,7 @@ abstract class ConnectionPool implements Pool
         \assert(isset($this->connections[$connection]), 'Connection is not part of this pool');
 
         if ($connection->isAlive()) {
-            $this->idle->push($connection);
+            $this->idle->unshift($connection);
         } else {
             $this->connections->detach($connection);
         }


### PR DESCRIPTION
In source code, the pop() method invoke idle->shift() to get top of pool list connection to use, and push return it back to the bottom of list.

In timeoutWatcher first check bottom of the list connection, if not idle will do nothing.

If connection pool has expanded at peak, when the traffic drops back to a low peak, as long as there is one query in each idle time, all connection will never released!!! but only one or two connection is enough now.

So I think idle->push() should change to idle->unshift(), then real idle connection in bottom will be released in time, or timeoutWatcher check top, and pop() change to real idle->pop().

See also https://github.com/amphp/mysql/issues/99