### PR TITLE
Fix exception "Promise has already been resolved" when reached limit of connections

### DIFF
--- a/src/ConnectionPool.php
+++ b/src/ConnectionPool.php
@@ -309,7 +309,8 @@ abstract class ConnectionPool implements Pool
             $this->connections->detach($connection);
         }
 
-        if ($this->deferred instanceof Deferred) {
+        if ($this->deferred instanceof Deferred
+            && !$this->deferred->isResolved()) {
             $this->deferred->resolve($connection);
         }
     }


### PR DESCRIPTION
When I set, for instance, max 5 connections like 
```
new AmpMySql\Pool($config, 5);
```
It's throwing an exception when this limit has reached and need to wait for one of the connection releases.